### PR TITLE
Adding LEDs and intake changes

### DIFF
--- a/src/main/java/frc/robot/intake/Intake.java
+++ b/src/main/java/frc/robot/intake/Intake.java
@@ -27,7 +27,7 @@ public class Intake extends Mechanism {
         // Algae Voltages and Current
         @Getter @Setter private double algaeIntakeVoltage = -9.0;
         @Getter @Setter private double algaeIntakeSupplyCurrent = 30.0;
-        @Getter @Setter private double algaeIntakeTorqueCurrent = 85.0;
+        @Getter @Setter private double algaeIntakeTorqueCurrent = -85.0;
 
         @Getter @Setter private double algaeScoreVoltage = 12.0;
         @Getter @Setter private double algaeScoreSupplyCurrent = 30.0;
@@ -36,7 +36,7 @@ public class Intake extends Mechanism {
         // Coral Voltages and Current
         @Getter @Setter private double coralHoldVoltage = 9.0;
         @Getter @Setter private double coralHoldSupplyCurrent = 30.0;
-        @Getter @Setter private double coralHoldTorqueCurrent = 15.0;
+        @Getter @Setter private double coralHoldTorqueCurrent = 30.0;
 
         @Getter @Setter private double coralIntakeVoltage = 12.0;
         @Getter @Setter private double coralIntakeSupplyCurrent = 30.0;
@@ -48,15 +48,15 @@ public class Intake extends Mechanism {
 
         @Getter @Setter private double coralScoreVoltage = -1;
         @Getter @Setter private double coralScoreSupplyCurrent = 12.0;
-        @Getter @Setter private double coralScoreTorqueCurrent = 40.0;
+        @Getter @Setter private double coralScoreTorqueCurrent = -25.0;
 
         @Getter @Setter private double coralL1ScoreVoltage = -8;
         @Getter @Setter private double coralL1ScoreSupplyCurrent = 15.0;
-        @Getter @Setter private double coralL1ScoreTorqueCurrent = 60.0;
+        @Getter @Setter private double coralL1ScoreTorqueCurrent = -30.0;
 
         /* Intake config values */
-        @Getter private double currentLimit = 15;
-        @Getter private double torqueCurrentLimit = 100;
+        @Getter private double currentLimit = 40;
+        @Getter private double torqueCurrentLimit = 180;
         @Getter private double velocityKp = 12; // 0.156152;
         @Getter private double velocityKv = 0.2; // 0.12;
         @Getter private double velocityKs = 14;
@@ -127,15 +127,13 @@ public class Intake extends Mechanism {
         return run(
                 () -> {
                     if (RobotStates.coral.getAsBoolean()) {
-                        setVoltageOutput(() -> config.getCoralHoldVoltage());
-                        setCurrentLimits(
-                                () -> config.getCoralHoldSupplyCurrent(),
-                                () -> config.getCoralHoldTorqueCurrent());
+                        // setVoltageOutput(() -> config.getCoralHoldVoltage());
+                        // setCurrentLimits(
+                        //         () -> config.getCoralHoldSupplyCurrent(),
+                        //         () -> config.getCoralHoldTorqueCurrent());
+                        setTorqueCurrentFoc(config::getCoralHoldTorqueCurrent);
                     } else if (RobotStates.algae.getAsBoolean()) {
-                        runVoltage(() -> config.getAlgaeIntakeVoltage());
-                        setCurrentLimits(
-                                () -> config.getAlgaeIntakeSupplyCurrent(),
-                                () -> config.getAlgaeIntakeTorqueCurrent());
+                        setTorqueCurrentFoc(config::getAlgaeIntakeTorqueCurrent);
                     } else {
                         stop();
                     }
@@ -147,6 +145,10 @@ public class Intake extends Mechanism {
         double motorCurrent = getStatorCurrent();
         return (Math.abs(motorOutput) < config.hasGamePieceVelocity
                 && Math.abs(motorCurrent) > config.hasGamePieceCurrent);
+    }
+
+    public Command runTorqueFOC(DoubleSupplier torque) {
+        return run(() -> setTorqueCurrentFoc(torque));
     }
 
     public Command intakeCoral(DoubleSupplier torque, DoubleSupplier current) {

--- a/src/main/java/frc/robot/intake/IntakeStates.java
+++ b/src/main/java/frc/robot/intake/IntakeStates.java
@@ -41,50 +41,52 @@ public class IntakeStates {
 
         netAlgae.and(actionState)
                 .whileTrue(
-                        runVoltageCurrentLimits(
-                                config::getAlgaeScoreVoltage,
-                                config::getAlgaeScoreSupplyCurrent,
-                                config::getAlgaeScoreTorqueCurrent));
+                        // runVoltageCurrentLimits(
+                        //         config::getAlgaeScoreVoltage,
+                        //         config::getAlgaeScoreSupplyCurrent,
+                        //         config::getAlgaeScoreTorqueCurrent));
+                        intake.runTorqueFOC(config::getAlgaeScoreTorqueCurrent));
 
         // hasGamePiece.onTrue(intake.getDefaultCommand());
 
         stationIntaking
                 .or(photonAlgaeRemoval)
-                // .whileTrue(runVoltageCurrentLimits(
-                //         config::getCoralIntakeVoltage,
-                //         config::getCoralIntakeSupplyCurrent,
-                //         config::getCoralIntakeTorqueCurrent));
                 .whileTrue(
-                        intake.intakeCoral(
-                                        config::getCoralIntakeTorqueCurrent,
-                                        config::getCoralIntakeSupplyCurrent)
-                                .withName("Intake.StationIntaking"));
+                        // intake.intakeCoral(
+                        //                 config::getCoralIntakeTorqueCurrent,
+                        //                 config::getCoralIntakeSupplyCurrent)
+                        //         .withName("Intake.StationIntaking"));
+                        intake.runTorqueFOC(config::getCoralIntakeTorqueCurrent));
 
         groundCoral.whileTrue(
-                intake.intakeCoral(
-                                config::getCoralGroundTorqueCurrent,
-                                config::getCoralGroundSupplyCurrent)
-                        .withName("Intake.GroundCoral"));
+                // intake.intakeCoral(
+                //                 config::getCoralGroundTorqueCurrent,
+                //                 config::getCoralGroundSupplyCurrent)
+                //         .withName("Intake.GroundCoral"));
+                intake.runTorqueFOC(config::getCoralGroundTorqueCurrent));
 
         algae.and(photon.not())
                 .whileTrue(
-                        intake.intakeAlgae(
-                                        config::getAlgaeIntakeTorqueCurrent,
-                                        config::getAlgaeIntakeSupplyCurrent)
-                                .withName("Intake.Algae"));
+                        // intake.intakeAlgae(
+                        //                 config::getAlgaeIntakeTorqueCurrent,
+                        //                 config::getAlgaeIntakeSupplyCurrent)
+                        //         .withName("Intake.Algae"));
+                        intake.runTorqueFOC(config::getAlgaeIntakeTorqueCurrent));
 
         L1Coral.and(actionState)
                 .whileTrue(
-                        runVoltageCurrentLimits(
-                                config::getCoralL1ScoreVoltage,
-                                config::getCoralL1ScoreSupplyCurrent,
-                                config::getCoralL1ScoreTorqueCurrent));
+                        // runVoltageCurrentLimits(
+                        //         config::getCoralL1ScoreVoltage,
+                        //         config::getCoralL1ScoreSupplyCurrent,
+                        //         config::getCoralL1ScoreTorqueCurrent));
+                        intake.runTorqueFOC(config::getCoralL1ScoreTorqueCurrent));
         branch.and(actionState)
                 .whileTrue(
-                        runVoltageCurrentLimits(
-                                config::getCoralScoreVoltage,
-                                config::getCoralScoreSupplyCurrent,
-                                config::getCoralScoreTorqueCurrent));
+                        // runVoltageCurrentLimits(
+                        //         config::getCoralScoreVoltage,
+                        //         config::getCoralScoreSupplyCurrent,
+                        //         config::getCoralScoreTorqueCurrent));
+                        intake.runTorqueFOC(config::getCoralScoreTorqueCurrent));
 
         autonScore
                 .and(photon)
@@ -99,13 +101,6 @@ public class IntakeStates {
 
         coastMode.whileTrue(log(coastMode()));
         coastMode.onFalse(log(ensureBrakeMode()));
-        Robot.getPilot()
-                .testTune_tA
-                .whileTrue(
-                        intake.intakeCoral(
-                                        config::getCoralIntakeTorqueCurrent,
-                                        config::getCoralIntakeSupplyCurrent)
-                                .withName("Intake.StationIntaking"));
     }
 
     private static Command coastMode() {

--- a/src/main/java/frc/robot/leds/LedStates.java
+++ b/src/main/java/frc/robot/leds/LedStates.java
@@ -49,6 +49,7 @@ public class LedStates {
         seesTagDefault(VisionStates.seeingTag.and(Util.teleop), 5);
         seesTagAndCoralMode(VisionStates.seeingTag.and(RobotStates.coral, Util.teleop), 7);
         seesTagAndAlgaeMode(VisionStates.seeingTag.and(RobotStates.algae, Util.teleop), 7);
+        seesTagAndRightCoral(VisionStates.seeingTag.and(RobotStates.rightScore, Util.teleop), 9);
     }
 
     /** Default LED commands for each mode */
@@ -261,6 +262,21 @@ public class LedStates {
                 "left.SeesTagAndAlgaeMode",
                 left,
                 left.edges(Color.kYellow, 5).overlayOn(left.solid(Color.kMediumSeaGreen)),
+                priority,
+                trigger);
+    }
+
+    static void seesTagAndRightCoral(Trigger trigger, int priority) {
+        ledCommand(
+                "right.SeesTagAndRightCoral",
+                right,
+                right.edges(Color.kYellow, 5).overlayOn(right.solid(Color.kGreen)),
+                priority,
+                trigger);
+        ledCommand(
+                "left.SeesTagAndRightCoral",
+                left,
+                left.edges(Color.kYellow, 5).overlayOn(right.solid(Color.kGreen)),
                 priority,
                 trigger);
     }

--- a/src/main/java/frc/robot/leds/LedStates.java
+++ b/src/main/java/frc/robot/leds/LedStates.java
@@ -276,7 +276,7 @@ public class LedStates {
         ledCommand(
                 "left.SeesTagAndRightCoral",
                 left,
-                left.edges(Color.kYellow, 5).overlayOn(right.solid(Color.kGreen)),
+                left.edges(Color.kYellow, 5).overlayOn(left.solid(Color.kGreen)),
                 priority,
                 trigger);
     }

--- a/src/main/java/frc/robot/leds/LedStates.java
+++ b/src/main/java/frc/robot/leds/LedStates.java
@@ -30,8 +30,8 @@ public class LedStates {
         // homeFinishLED(RobotStates.isAtHome.and(Util.teleop, RobotStates.staged.not()), 8);
 
         // // Coral and Algae Led Commands
-        // coralModeLED(RobotStates.coral.and(Util.teleop), 6);
-        // algaeModeLED(RobotStates.algae.and(Util.teleop), 6);
+        coralModeLED(RobotStates.coral.and(Util.teleop), 6);
+        algaeModeLED(RobotStates.algae.and(Util.teleop), 6);
         // coralStagedLED(RobotStates.stagedCoral.and(Util.teleop), 7);
         // algaeStagedLED(RobotStates.stagedAlgae.and(Util.teleop), 7);
         // hasCoralLED(IntakeStates.hasCoral.and(Util.teleop), 7);
@@ -150,9 +150,12 @@ public class LedStates {
     }
 
     static void coralModeLED(Trigger trigger, int priority) {
-        withReverseLedCommand(
-                "right.CoralMode", right, right.solid(Color.kCoral), priority, trigger);
-        withReverseLedCommand("left.CoralMode", left, left.solid(Color.kCoral), priority, trigger);
+        // withReverseLedCommand(
+        //         "right.CoralMode", right, right.solid(Color.kCoral), priority, trigger);
+        // withReverseLedCommand("left.CoralMode", left, left.solid(Color.kCoral), priority,
+        // trigger);
+        ledCommand("right.CoralMode", right, right.solid(Color.kCoral), priority, trigger);
+        ledCommand("left.CoralMode", left, left.solid(Color.kCoral), priority, trigger);
     }
 
     static void algaeModeLED(Trigger trigger, int priority) {
@@ -160,6 +163,8 @@ public class LedStates {
         //         "right.AlgaeMode", right, right.solid(Color.kMediumSeaGreen), priority, trigger);
         // withReverseLedCommand(
         //         "left.AlgaeMode", left, left.solid(Color.kMediumSeaGreen), priority, trigger);
+        ledCommand("right.AlgaeMode", right, right.solid(Color.kMediumSeaGreen), priority, trigger);
+        ledCommand("left.AlgaeMode", left, left.solid(Color.kMediumSeaGreen), priority, trigger);
     }
 
     static void coralStagedLED(Trigger trigger, int priority) {

--- a/src/main/java/frc/robot/leds/LedStates.java
+++ b/src/main/java/frc/robot/leds/LedStates.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Robot;
 import frc.robot.RobotStates;
+import frc.robot.vision.VisionStates;
 import frc.spectrumLib.Telemetry;
 import frc.spectrumLib.leds.SpectrumLEDs;
 import frc.spectrumLib.util.Util;
@@ -43,6 +44,11 @@ public class LedStates {
 
         // Climb Led Commands
         // climbReadyLED(ClimbStates.isLatched.and(RobotStates.climbPrep, Util.teleop), 6);
+
+        // Limelight Led Commands
+        seesTagDefault(VisionStates.seeingTag.and(Util.teleop), 5);
+        seesTagAndCoralMode(VisionStates.seeingTag.and(RobotStates.coral, Util.teleop), 7);
+        seesTagAndAlgaeMode(VisionStates.seeingTag.and(RobotStates.algae, Util.teleop), 7);
     }
 
     /** Default LED commands for each mode */
@@ -222,6 +228,41 @@ public class LedStates {
                 trigger);
         withReverseLedCommand(
                 "left.HasAlgae", left, left.breathe(Color.kMediumSeaGreen, 1), priority, trigger);
+    }
+
+    static void seesTagDefault(Trigger trigger, int priority) {
+        ledCommand("right.SeesTag", right, right.bounce(Color.kYellow, 3), priority, trigger);
+        ledCommand("left.SeesTag", left, left.bounce(Color.kYellow, 3), priority, trigger);
+    }
+
+    static void seesTagAndCoralMode(Trigger trigger, int priority) {
+        ledCommand(
+                "right.SeesTagAndCoralMode",
+                right,
+                right.edges(Color.kYellow, 5).overlayOn(right.solid(Color.kCoral)),
+                priority,
+                trigger);
+        ledCommand(
+                "left.SeesTagAndCoralMode",
+                left,
+                left.edges(Color.kYellow, 5).overlayOn(left.solid(Color.kCoral)),
+                priority,
+                trigger);
+    }
+
+    static void seesTagAndAlgaeMode(Trigger trigger, int priority) {
+        ledCommand(
+                "right.SeesTagAndAlgaeMode",
+                right,
+                right.edges(Color.kYellow, 5).overlayOn(right.solid(Color.kMediumSeaGreen)),
+                priority,
+                trigger);
+        ledCommand(
+                "left.SeesTagAndAlgaeMode",
+                left,
+                left.edges(Color.kYellow, 5).overlayOn(left.solid(Color.kMediumSeaGreen)),
+                priority,
+                trigger);
     }
 
     // Log Command

--- a/src/main/java/frc/robot/vision/VisionStates.java
+++ b/src/main/java/frc/robot/vision/VisionStates.java
@@ -9,6 +9,7 @@ public class VisionStates {
     private static Vision vision = Robot.getVision();
 
     public static final Trigger usingRearTag = new Trigger(vision::isRearTagClosest);
+    public static final Trigger seeingTag = new Trigger(vision::tagsInView);
 
     public static void setupDefaultCommand() {
         vision.setDefaultCommand(vision.blinkLimelights().withName("Vision.default"));

--- a/src/main/java/frc/spectrumLib/mechanism/Mechanism.java
+++ b/src/main/java/frc/spectrumLib/mechanism/Mechanism.java
@@ -670,10 +670,10 @@ public abstract class Mechanism implements NTSendable, SpectrumSubsystem {
             if (config.talonConfig.CurrentLimits.StatorCurrentLimit != statorLimit.getAsDouble()
                     && config.talonConfig.CurrentLimits.SupplyCurrentLimit
                             != supplyLimit.getAsDouble()) {
-                config.configSupplyCurrentLimit(supplyLimit.getAsDouble(), true);
-                config.configStatorCurrentLimit(statorLimit.getAsDouble(), true);
-                config.configForwardTorqueCurrentLimit(statorLimit.getAsDouble());
-                config.configReverseTorqueCurrentLimit(-1 * statorLimit.getAsDouble());
+                config.configSupplyCurrentLimit(Math.abs(supplyLimit.getAsDouble()), true);
+                config.configStatorCurrentLimit(Math.abs(statorLimit.getAsDouble()), true);
+                config.configForwardTorqueCurrentLimit(Math.abs(statorLimit.getAsDouble()));
+                config.configReverseTorqueCurrentLimit(-1 * Math.abs(statorLimit.getAsDouble()));
                 for (int i = 0; i < 10; i++) {
                     StatusCode result = motor.getConfigurator().apply(config.talonConfig);
                     if (!result.isOK()) {


### PR DESCRIPTION
LEDs for coral and algae mode are back
LEDs are yellow when the robot sees a tag (bounce on default, tips over other LEDs)

Intaking and scoring uses torque control instead of current limit setting